### PR TITLE
feat: Add basic support for Multipart Upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added support for `CreateMultipartUpload`, `UploadPart` and `CompleteMultipartUpload` operations.
+
 ## v1.0.0 - 2024-09-04
 
 - Initial release with create_bucket, delete_bucket, delete_object,

--- a/README.md
+++ b/README.md
@@ -67,5 +67,8 @@ The following endpoints are supported:
 - [ListBuckets](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html)
 - [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html)
 - [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
+- [CreateMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html)
+- [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
+- [CompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)
 
 Further documentation can be found at <https://hexdocs.pm/bucket>.

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -42,10 +42,6 @@ pub fn request(
   upload_id upload_id: String,
   parts parts: List(Part),
 ) -> RequestBuilder {
-  let parts =
-    // Sort parts by part_number so the user doesn't have to. If the parts weren't sorted,
-    // the CompleteMultipartUpload request would fail.
-    list.sort(parts, fn(a, b) { int.compare(a.part_number, b.part_number) })
   RequestBuilder(bucket:, key:, upload_id:, parts:)
 }
 

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -8,7 +8,6 @@ import gleam/http/response.{type Response}
 import gleam/int
 import gleam/list
 import gleam/option
-import gleam/result
 import gleam/string_builder
 import xmb
 

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -1,4 +1,6 @@
 //// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html>
+////
+//// CompleteMultipartUpload operation creates a new object by combining the specified parts. You may omit any number of parts, but they must be specified in ascending order.
 
 import bucket.{type BucketError, type Credentials}
 import bucket/internal

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -40,6 +40,10 @@ pub fn request(
   upload_id upload_id: String,
   parts parts: List(Part),
 ) -> RequestBuilder {
+  let parts =
+    // Sort parts by part_number so the user doesn't have to. If the parts weren't sorted,
+    // the CompleteMultipartUpload request would fail.
+    list.sort(parts, fn(a, b) { int.compare(a.part_number, b.part_number) })
   RequestBuilder(bucket:, key:, upload_id:, parts:)
 }
 

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -1,3 +1,5 @@
+//// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html>
+
 import bucket.{type BucketError, type Credentials}
 import bucket/internal
 import bucket/internal/xml

--- a/src/bucket/complete_multipart_upload.gleam
+++ b/src/bucket/complete_multipart_upload.gleam
@@ -1,0 +1,101 @@
+import bucket.{type BucketError, type Credentials}
+import bucket/internal
+import bucket/internal/xml
+import gleam/bit_array
+import gleam/http
+import gleam/http/request.{type Request, Request}
+import gleam/http/response.{type Response}
+import gleam/int
+import gleam/list
+import gleam/option
+import gleam/result
+import gleam/string_builder
+import xmb
+
+pub type CompleteMultipartUploadResult {
+  CompleteMultipartUploadResult(
+    location: String,
+    bucket: String,
+    key: String,
+    etag: String,
+  )
+}
+
+/// The parameters for the API request
+pub type RequestBuilder {
+  RequestBuilder(
+    bucket: String,
+    key: String,
+    upload_id: String,
+    parts: List(Part),
+  )
+}
+
+pub type Part {
+  Part(part_number: Int, etag: String)
+}
+
+pub fn request(
+  bucket bucket: String,
+  key key: String,
+  upload_id upload_id: String,
+  parts parts: List(Part),
+) -> RequestBuilder {
+  RequestBuilder(bucket:, key:, upload_id:, parts:)
+}
+
+pub fn build(builder: RequestBuilder, creds: Credentials) -> Request(BitArray) {
+  let body =
+    xmb.x(
+      "CompleteMultipartUpload",
+      [#("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/")],
+      list.map(builder.parts, fn(part) {
+        xmb.x("Part", [], [
+          xmb.x("PartNumber", [], [xmb.text(int.to_string(part.part_number))]),
+          xmb.x("ETag", [], [xmb.text(part.etag)]),
+        ])
+      }),
+    )
+    |> xmb.render_fragment
+    |> string_builder.to_string
+    |> bit_array.from_string
+  internal.request(
+    creds,
+    http.Post,
+    "/" <> builder.bucket <> "/" <> builder.key,
+    [#("uploadId", option.Some(builder.upload_id))],
+    [],
+    body,
+  )
+}
+
+pub fn response(
+  response: Response(BitArray),
+) -> Result(CompleteMultipartUploadResult, BucketError) {
+  case response.status {
+    200 -> response_success(response)
+    _ -> internal.s3_error(response)
+  }
+}
+
+fn response_success(
+  response: Response(BitArray),
+) -> Result(CompleteMultipartUploadResult, BucketError) {
+  xml.element(
+    "CompleteMultipartUploadResult",
+    CompleteMultipartUploadResult("", "", "", ""),
+  )
+  |> xml.keep_text("Location", fn(r, v) {
+    CompleteMultipartUploadResult(..r, location: v)
+  })
+  |> xml.keep_text("Bucket", fn(r, v) {
+    CompleteMultipartUploadResult(..r, bucket: v)
+  })
+  |> xml.keep_text("Key", fn(r, v) {
+    CompleteMultipartUploadResult(..r, key: v)
+  })
+  |> xml.keep_text("ETag", fn(r, v) {
+    CompleteMultipartUploadResult(..r, etag: v)
+  })
+  |> xml.parse(response.body)
+}

--- a/src/bucket/create_multipart_upload.gleam
+++ b/src/bucket/create_multipart_upload.gleam
@@ -1,0 +1,57 @@
+import bucket.{type BucketError, type Credentials}
+import bucket/internal
+import bucket/internal/xml
+import gleam/http
+import gleam/http/request.{type Request, Request}
+import gleam/http/response.{type Response}
+import gleam/option
+
+pub type CreateMultipartUploadResult {
+  CreateMultipartUploadResult(bucket: String, key: String, upload_id: String)
+}
+
+/// The parameters for the API request
+pub type RequestBuilder {
+  RequestBuilder(bucket: String, key: String)
+}
+
+pub fn request(bucket bucket: String, key key: String) -> RequestBuilder {
+  RequestBuilder(bucket:, key:)
+}
+
+pub fn build(builder: RequestBuilder, creds: Credentials) -> Request(BitArray) {
+  internal.request(
+    creds,
+    http.Post,
+    "/" <> builder.bucket <> "/" <> builder.key,
+    [#("uploads", option.Some(""))],
+    [],
+    <<>>,
+  )
+}
+
+pub fn response(
+  response: Response(BitArray),
+) -> Result(CreateMultipartUploadResult, BucketError) {
+  case response.status {
+    200 -> response_success(response)
+    _ -> internal.s3_error(response)
+  }
+}
+
+fn response_success(
+  response: Response(BitArray),
+) -> Result(CreateMultipartUploadResult, BucketError) {
+  xml.element(
+    "InitiateMultipartUploadResult",
+    CreateMultipartUploadResult("", "", ""),
+  )
+  |> xml.keep_text("Bucket", fn(r, v) {
+    CreateMultipartUploadResult(..r, bucket: v)
+  })
+  |> xml.keep_text("Key", fn(r, v) { CreateMultipartUploadResult(..r, key: v) })
+  |> xml.keep_text("UploadId", fn(r, v) {
+    CreateMultipartUploadResult(..r, upload_id: v)
+  })
+  |> xml.parse(response.body)
+}

--- a/src/bucket/create_multipart_upload.gleam
+++ b/src/bucket/create_multipart_upload.gleam
@@ -1,3 +1,5 @@
+//// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html>
+
 import bucket.{type BucketError, type Credentials}
 import bucket/internal
 import bucket/internal/xml

--- a/src/bucket/upload_part.gleam
+++ b/src/bucket/upload_part.gleam
@@ -15,6 +15,8 @@ pub type UploadPartResult {
 }
 
 /// The parameters for the API request
+///
+/// The `part_number` can be any number from 1 to 10,000, inclusive. A part number uniquely identifies a part and also defines its position within the object being created. If you upload a new part using the same part number that was used with a previous part, the previously uploaded part is overwritten.
 pub type RequestBuilder {
   RequestBuilder(
     bucket: String,

--- a/src/bucket/upload_part.gleam
+++ b/src/bucket/upload_part.gleam
@@ -1,0 +1,64 @@
+import bucket.{type BucketError, type Credentials}
+import bucket/internal
+import gleam/http
+import gleam/http/request.{type Request, Request}
+import gleam/http/response.{type Response}
+import gleam/int
+import gleam/list
+import gleam/option
+import gleam/result
+
+pub type UploadPartResult {
+  UploadPartResult(etag: String)
+}
+
+/// The parameters for the API request
+pub type RequestBuilder {
+  RequestBuilder(
+    bucket: String,
+    key: String,
+    upload_id: String,
+    part_number: Int,
+    body: BitArray,
+  )
+}
+
+pub fn request(
+  bucket bucket: String,
+  key key: String,
+  upload_id upload_id: String,
+  part_number part_number: Int,
+  body body: BitArray,
+) -> RequestBuilder {
+  RequestBuilder(bucket:, key:, upload_id:, part_number:, body:)
+}
+
+pub fn build(builder: RequestBuilder, creds: Credentials) -> Request(BitArray) {
+  internal.request(
+    creds,
+    http.Put,
+    "/" <> builder.bucket <> "/" <> builder.key,
+    [
+      #("partNumber", option.Some(int.to_string(builder.part_number))),
+      #("uploadId", option.Some(builder.upload_id)),
+    ],
+    [],
+    builder.body,
+  )
+}
+
+pub fn response(
+  response: Response(BitArray),
+) -> Result(UploadPartResult, BucketError) {
+  case response.status {
+    200 -> response_success(response)
+    _ -> internal.s3_error(response)
+  }
+}
+
+fn response_success(
+  response: Response(BitArray),
+) -> Result(UploadPartResult, BucketError) {
+  let etag = list.key_find(response.headers, "etag") |> result.unwrap("")
+  Ok(UploadPartResult(etag:))
+}

--- a/src/bucket/upload_part.gleam
+++ b/src/bucket/upload_part.gleam
@@ -1,3 +1,5 @@
+//// <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html>
+
 import bucket.{type BucketError, type Credentials}
 import bucket/internal
 import gleam/http

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -98,3 +98,6 @@ pub fn does_object_exist(bucket: String, key: String) -> Bool {
   let assert Ok(res) = head_object.response(res)
   res == head_object.Found
 }
+
+@external(erlang, "rand", "bytes")
+pub fn get_random_bytes(num_bytes: Int) -> BitArray

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -2,6 +2,7 @@ import bucket
 import bucket/create_bucket
 import bucket/delete_bucket
 import bucket/delete_objects
+import bucket/get_object
 import bucket/head_object
 import bucket/list_buckets
 import bucket/list_objects
@@ -97,6 +98,15 @@ pub fn does_object_exist(bucket: String, key: String) -> Bool {
     |> httpc.send_bits
   let assert Ok(res) = head_object.response(res)
   res == head_object.Found
+}
+
+pub fn get_object(bucket: String, key: String) -> BitArray {
+  let assert Ok(res) =
+    get_object.request(bucket, key)
+    |> get_object.build(creds)
+    |> httpc.send_bits
+  let assert Ok(get_object.Found(contents)) = get_object.response(res)
+  contents
 }
 
 @external(erlang, "rand", "bytes")

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -146,7 +146,7 @@ pub fn entity_too_small_test() {
   |> should.equal("/" <> bucket <> "/" <> key)
 }
 
-// Attempt to complete a multipart upload with an incorrect ETag in one of the parts
+/// Attempt to complete a multipart upload with an incorrect ETag in one of the parts
 pub fn invalid_part_test() {
   // Set up a test bucket
   helpers.delete_existing_buckets()
@@ -198,7 +198,7 @@ pub fn invalid_part_test() {
   |> should.equal("/" <> bucket <> "/" <> key)
 }
 
-// Attempt to complete a multipart upload with parts in an invalid order
+/// Attempt to complete a multipart upload with parts in an invalid order
 pub fn invalid_part_order_test() {
   // Set up a test bucket
   helpers.delete_existing_buckets()

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -1,0 +1,19 @@
+import bucket/create_multipart_upload
+import gleam/httpc
+import gleeunit/should
+import helpers
+
+pub fn perform_multipart_upload_test() {
+  helpers.delete_existing_buckets()
+  helpers.create_bucket("multipart1")
+
+  // Initiate a multipart upload
+  let assert Ok(res) =
+    create_multipart_upload.request(bucket: "multipart1", key: "test/file")
+    |> create_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = create_multipart_upload.response(res)
+  should.equal(res.bucket, "multipart1")
+  should.equal(res.key, "test/file")
+  should.not_equal(res.upload_id, "")
+}

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -1,3 +1,4 @@
+import bucket.{ErrorObject, S3Error}
 import bucket/complete_multipart_upload
 import bucket/create_multipart_upload
 import bucket/get_object
@@ -9,10 +10,11 @@ import gleam/string
 import gleeunit/should
 import helpers
 
+/// Perform a basic multipart upload and verify it works as expected
 pub fn perform_multipart_upload_test() {
   // Set up a test bucket
   helpers.delete_existing_buckets()
-  let bucket = "multipart1"
+  let bucket = "multipart"
   helpers.create_bucket(bucket)
 
   // Initiate a multipart upload
@@ -76,4 +78,233 @@ pub fn perform_multipart_upload_test() {
     bit_array.slice(from: contents, at: 2 * part_size, take: 8),
     Ok(part3),
   )
+}
+
+/// Attempt to complete a multipart upload with parts smaller than the minimum size
+pub fn entity_too_small_test() {
+  // Set up a test bucket
+  helpers.delete_existing_buckets()
+  let bucket = "multipart"
+  helpers.create_bucket(bucket)
+
+  // Initiate a multipart upload
+  let key = "test/myfile"
+  let assert Ok(res) =
+    create_multipart_upload.request(bucket:, key:)
+    |> create_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = create_multipart_upload.response(res)
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.upload_id, "")
+
+  // Upload the parts
+  let upload_id = res.upload_id
+  let part_size = 2 * 1024 * 1024
+  let part1 = helpers.get_random_bytes(part_size)
+  let part2 = helpers.get_random_bytes(part_size)
+  let part3 = <<"Goodbye!":utf8>>
+  let parts =
+    [part1, part2, part3]
+    |> list.index_map(fn(body, i) {
+      let part_number = i + 1
+      let assert Ok(res) =
+        upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
+        |> upload_part.build(helpers.creds)
+        |> httpc.send_bits
+      let assert Ok(res) = upload_part.response(res)
+      should.not_equal(res.etag, "")
+      complete_multipart_upload.Part(part_number:, etag: res.etag)
+    })
+
+  // Complete the multipart upload
+  let assert Ok(res) =
+    complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
+    |> complete_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Error(res) = complete_multipart_upload.response(res)
+  let assert S3Error(
+    http_status:,
+    error: ErrorObject(code:, message:, request_id:, resource:),
+  ) = res
+
+  http_status
+  |> should.equal(400)
+
+  code
+  |> should.equal("EntityTooSmall")
+
+  message
+  |> should.equal(
+    "Your proposed upload is smaller than the minimum allowed object size.",
+  )
+
+  request_id
+  |> should.not_equal("")
+
+  resource
+  |> should.equal("/" <> bucket <> "/" <> key)
+}
+
+// Attempt to complete a multipart upload with an incorrect ETag in one of the parts
+pub fn invalid_part_test() {
+  // Set up a test bucket
+  helpers.delete_existing_buckets()
+  let bucket = "multipart"
+  helpers.create_bucket(bucket)
+
+  // Initiate a multipart upload
+  let key = "test/myfile"
+  let assert Ok(res) =
+    create_multipart_upload.request(bucket:, key:)
+    |> create_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = create_multipart_upload.response(res)
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.upload_id, "")
+
+  // Complete the multipart upload, no need to upload parts for this test
+  let upload_id = res.upload_id
+  let parts = [
+    complete_multipart_upload.Part(part_number: 1, etag: "incorrect"),
+    complete_multipart_upload.Part(part_number: 2, etag: "also incorrect"),
+  ]
+  let assert Ok(res) =
+    complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
+    |> complete_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Error(res) = complete_multipart_upload.response(res)
+  let assert S3Error(
+    http_status:,
+    error: ErrorObject(code:, message:, request_id:, resource:),
+  ) = res
+
+  http_status
+  |> should.equal(400)
+
+  code
+  |> should.equal("InvalidPart")
+
+  message
+  |> should.equal(
+    "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+  )
+
+  request_id
+  |> should.not_equal("")
+
+  resource
+  |> should.equal("/" <> bucket <> "/" <> key)
+}
+
+// Attempt to complete a multipart upload with parts in an invalid order
+pub fn invalid_part_order_test() {
+  // Set up a test bucket
+  helpers.delete_existing_buckets()
+  let bucket = "multipart"
+  helpers.create_bucket(bucket)
+
+  // Initiate a multipart upload
+  let key = "test/myfile"
+  let assert Ok(res) =
+    create_multipart_upload.request(bucket:, key:)
+    |> create_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = create_multipart_upload.response(res)
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.upload_id, "")
+
+  // Upload the parts
+  let upload_id = res.upload_id
+  let part_size = 5 * 1024 * 1024
+  let part1 = helpers.get_random_bytes(part_size)
+  let part2 = helpers.get_random_bytes(part_size)
+  let part3 = <<"Goodbye!":utf8>>
+  let parts =
+    [part1, part2, part3]
+    |> list.index_map(fn(body, i) {
+      let part_number = i + 1
+      let assert Ok(res) =
+        upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
+        |> upload_part.build(helpers.creds)
+        |> httpc.send_bits
+      let assert Ok(res) = upload_part.response(res)
+      should.not_equal(res.etag, "")
+      complete_multipart_upload.Part(part_number:, etag: res.etag)
+    })
+
+  // Complete the multipart upload, with the parts in an incorrect order
+  let parts = list.reverse(parts)
+  let assert Ok(res) =
+    complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
+    |> complete_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Error(res) = complete_multipart_upload.response(res)
+  let assert S3Error(
+    http_status:,
+    error: ErrorObject(code:, message:, request_id:, resource:),
+  ) = res
+
+  http_status
+  |> should.equal(400)
+
+  code
+  |> should.equal("InvalidPartOrder")
+
+  message
+  |> should.equal(
+    "The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+  )
+
+  request_id
+  |> should.not_equal("")
+
+  resource
+  |> should.equal("/" <> bucket <> "/" <> key)
+}
+
+/// Attempt to upload a part with incorrect upload_id
+pub fn no_such_upload_test() {
+  // Set up a test bucket
+  helpers.delete_existing_buckets()
+  let bucket = "multipart"
+  helpers.create_bucket(bucket)
+
+  // Upload a part
+  let key = "test/myfile"
+  let part_body = helpers.get_random_bytes(5 * 1024 * 1024)
+  let assert Ok(res) =
+    upload_part.request(
+      bucket:,
+      key:,
+      upload_id: "incorrect",
+      part_number: 1,
+      body: part_body,
+    )
+    |> upload_part.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Error(res) = upload_part.response(res)
+  let assert S3Error(
+    http_status:,
+    error: ErrorObject(code:, message:, request_id:, resource:),
+  ) = res
+
+  http_status
+  |> should.equal(404)
+
+  code
+  |> should.equal("NoSuchUpload")
+
+  message
+  |> should.equal(
+    "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+  )
+
+  request_id
+  |> should.not_equal("")
+
+  resource
+  |> should.equal("/" <> bucket <> "/" <> key)
 }

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -30,8 +30,8 @@ pub fn perform_multipart_upload_test() {
   // NOTE: The minimum Part size for multipart upload is 5MiB, except the last part.
   let upload_id = res.upload_id
   let part_size = 5 * 1024 * 1024
-  let part1 = get_random_bytes(part_size)
-  let part2 = get_random_bytes(part_size)
+  let part1 = helpers.get_random_bytes(part_size)
+  let part2 = helpers.get_random_bytes(part_size)
   let part3 = <<"Goodbye!":utf8>>
   let parts =
     [part1, part2, part3]
@@ -77,6 +77,3 @@ pub fn perform_multipart_upload_test() {
     Ok(part3),
   )
 }
-
-@external(erlang, "rand", "bytes")
-pub fn get_random_bytes(num_bytes: Int) -> BitArray

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -1,7 +1,6 @@
 import bucket.{ErrorObject, S3Error}
 import bucket/complete_multipart_upload
 import bucket/create_multipart_upload
-import bucket/get_object
 import bucket/upload_part
 import gleam/bit_array
 import gleam/httpc
@@ -60,11 +59,7 @@ pub fn perform_multipart_upload_test() {
   should.not_equal(res.etag, "")
 
   // Get the uploaded object and verify its contents
-  let assert Ok(res) =
-    get_object.request(bucket, key)
-    |> get_object.build(helpers.creds)
-    |> httpc.send_bits
-  let assert Ok(get_object.Found(contents)) = get_object.response(res)
+  let contents = helpers.get_object(bucket, key)
   should.equal(bit_array.byte_size(contents), 2 * part_size + 8)
   should.equal(
     bit_array.slice(from: contents, at: 0, take: part_size),

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -1,7 +1,12 @@
+import bucket/complete_multipart_upload
 import bucket/create_multipart_upload
+import bucket/get_object
 import bucket/upload_part
+import gleam/bit_array
 import gleam/httpc
+import gleam/int
 import gleam/list
+import gleam/string
 import gleeunit/should
 import helpers
 
@@ -12,7 +17,7 @@ pub fn perform_multipart_upload_test() {
   helpers.create_bucket(bucket)
 
   // Initiate a multipart upload
-  let key = "test/file"
+  let key = "test/myfile"
   let assert Ok(res) =
     create_multipart_upload.request(bucket:, key:)
     |> create_multipart_upload.build(helpers.creds)
@@ -24,18 +29,50 @@ pub fn perform_multipart_upload_test() {
 
   // Upload some parts (they can be sent in any order)
   let upload_id = res.upload_id
-  [
-    #(<<"jumps over ":utf8>>, 2),
-    #(<<"The quick brown fox ":utf8>>, 1),
-    #(<<"the lazy dog.":utf8>>, 3),
-  ]
-  |> list.map(fn(pair) {
-    let #(body, part_number) = pair
-    let assert Ok(res) =
-      upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
-      |> upload_part.build(helpers.creds)
-      |> httpc.send_bits
-    let assert Ok(res) = upload_part.response(res)
-    should.not_equal(res.etag, "")
-  })
+  // NOTE: The minimum Part size for multipart upload is 5MiB (hardcoded in minio)
+  let megabyte = 1024 * 1024
+  let parts =
+    [
+      #(string.repeat("B", 5 * megabyte) |> bit_array.from_string, 2),
+      #(string.repeat("A", 5 * megabyte) |> bit_array.from_string, 1),
+      #(<<"Goodbye!":utf8>>, 3),
+    ]
+    |> list.map(fn(pair) {
+      let #(body, part_number) = pair
+      let assert Ok(res) =
+        upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
+        |> upload_part.build(helpers.creds)
+        |> httpc.send_bits
+      let assert Ok(res) = upload_part.response(res)
+      should.not_equal(res.etag, "")
+      complete_multipart_upload.Part(part_number:, etag: res.etag)
+    })
+
+  // Complete the multipart upload
+  // NOTE: The Parts must be sorted in ascending order for this operation
+  let parts =
+    list.sort(parts, fn(pa, pb) { int.compare(pa.part_number, pb.part_number) })
+  let assert Ok(res) =
+    complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
+    |> complete_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = complete_multipart_upload.response(res)
+  should.be_true(string.contains(res.location, "/" <> bucket <> "/" <> key))
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.etag, "")
+
+  // Get the object and verify its contents
+  let assert Ok(res) =
+    get_object.request(bucket, key)
+    |> get_object.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(get_object.Found(contents)) = get_object.response(res)
+  should.equal(bit_array.byte_size(contents), 2 * 5 * megabyte + 8)
+  let assert Ok(<<"AAAA":utf8>>) =
+    bit_array.slice(from: contents, at: 1, take: 4)
+  let assert Ok(<<"AABB":utf8>>) =
+    bit_array.slice(from: contents, at: 5 * megabyte - 2, take: 4)
+  let assert Ok(<<"BBGoodbye!":utf8>>) =
+    bit_array.slice(from: contents, at: 2 * 5 * megabyte + 8, take: -10)
 }

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -27,7 +27,7 @@ pub fn perform_multipart_upload_test() {
   should.not_equal(res.upload_id, "")
 
   // Upload some parts (they can be sent in parallel)
-  // NOTE: The minimum Part size for multipart upload is 5MiB (hardcoded in minio)
+  // NOTE: The minimum Part size for multipart upload is 5MiB, except the last part.
   let upload_id = res.upload_id
   let part_size = 5 * 1024 * 1024
   let part1 = get_random_bytes(part_size)

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -47,7 +47,6 @@ pub fn perform_multipart_upload_test() {
     })
 
   // Complete the multipart upload
-  // NOTE: The Parts must be sorted in ascending order for this operation
   let assert Ok(res) =
     complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
     |> complete_multipart_upload.build(helpers.creds)

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -1,19 +1,41 @@
 import bucket/create_multipart_upload
+import bucket/upload_part
 import gleam/httpc
+import gleam/list
 import gleeunit/should
 import helpers
 
 pub fn perform_multipart_upload_test() {
+  // Set up a test bucket
   helpers.delete_existing_buckets()
-  helpers.create_bucket("multipart1")
+  let bucket = "multipart1"
+  helpers.create_bucket(bucket)
 
   // Initiate a multipart upload
+  let key = "test/file"
   let assert Ok(res) =
-    create_multipart_upload.request(bucket: "multipart1", key: "test/file")
+    create_multipart_upload.request(bucket:, key:)
     |> create_multipart_upload.build(helpers.creds)
     |> httpc.send_bits
   let assert Ok(res) = create_multipart_upload.response(res)
-  should.equal(res.bucket, "multipart1")
-  should.equal(res.key, "test/file")
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
   should.not_equal(res.upload_id, "")
+
+  // Upload some parts (they can be sent in any order)
+  let upload_id = res.upload_id
+  [
+    #(<<"jumps over ":utf8>>, 2),
+    #(<<"The quick brown fox ":utf8>>, 1),
+    #(<<"the lazy dog.":utf8>>, 3),
+  ]
+  |> list.map(fn(pair) {
+    let #(body, part_number) = pair
+    let assert Ok(res) =
+      upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
+      |> upload_part.build(helpers.creds)
+      |> httpc.send_bits
+    let assert Ok(res) = upload_part.response(res)
+    should.not_equal(res.etag, "")
+  })
 }

--- a/test/multipart_test.gleam
+++ b/test/multipart_test.gleam
@@ -75,6 +75,70 @@ pub fn perform_multipart_upload_test() {
   )
 }
 
+/// S3 allows us to discard parts when completing a multipart upload
+pub fn complete_upload_skip_parts_test() {
+  // Set up a test bucket
+  helpers.delete_existing_buckets()
+  let bucket = "multipart"
+  helpers.create_bucket(bucket)
+
+  // Initiate a multipart upload
+  let key = "test/myfile"
+  let assert Ok(res) =
+    create_multipart_upload.request(bucket:, key:)
+    |> create_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = create_multipart_upload.response(res)
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.upload_id, "")
+
+  // Upload some parts
+  let upload_id = res.upload_id
+  let part_size = 5 * 1024 * 1024
+  let part1 = helpers.get_random_bytes(part_size)
+  let part2 = helpers.get_random_bytes(part_size)
+  let part3 = helpers.get_random_bytes(part_size)
+  let part4 = <<"Goodbye!":utf8>>
+  let parts =
+    [part1, part2, part3, part4]
+    |> list.index_map(fn(body, i) {
+      let part_number = i + 1
+      let assert Ok(res) =
+        upload_part.request(bucket:, key:, upload_id:, part_number:, body:)
+        |> upload_part.build(helpers.creds)
+        |> httpc.send_bits
+      let assert Ok(res) = upload_part.response(res)
+      should.not_equal(res.etag, "")
+      complete_multipart_upload.Part(part_number:, etag: res.etag)
+    })
+
+  // Complete the multipart upload, but discard part1 and part4
+  let assert [_, p2, p3, _] = parts
+  let parts = [p2, p3]
+  let assert Ok(res) =
+    complete_multipart_upload.request(bucket:, key:, upload_id:, parts:)
+    |> complete_multipart_upload.build(helpers.creds)
+    |> httpc.send_bits
+  let assert Ok(res) = complete_multipart_upload.response(res)
+  should.be_true(string.contains(res.location, "/" <> bucket <> "/" <> key))
+  should.equal(res.bucket, bucket)
+  should.equal(res.key, key)
+  should.not_equal(res.etag, "")
+
+  // Get the uploaded object and verify its contents
+  let contents = helpers.get_object(bucket, key)
+  should.equal(bit_array.byte_size(contents), 2 * part_size)
+  should.equal(
+    bit_array.slice(from: contents, at: 0, take: part_size),
+    Ok(part2),
+  )
+  should.equal(
+    bit_array.slice(from: contents, at: part_size, take: part_size),
+    Ok(part3),
+  )
+}
+
 /// Attempt to complete a multipart upload with parts smaller than the minimum size
 pub fn entity_too_small_test() {
   // Set up a test bucket


### PR DESCRIPTION
This PR adds support for `CreateMultipartUpload`, `UploadPart` and `CompleteMultipartUpload` S3 APIs. This lets the users of this library upload large files more quickly, by uploading multiple chunks in parallel.

There are other Multipart Upload APIs that could be implemented in the future:
- AbortMultipartUpload
- ListMultipartUploads
- ListParts
- UploadPartCopy

The full list of these APIs can be found on MinIO's docs: https://min.io/docs/minio/linux/reference/s3-api-compatibility.html#multipart-uploads
