### PR TITLE
refactor: parse host, port, and scheme from base_url for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pub fn main() {
   let assert Ok(Found(object)) = get_object.response(response)
 
   // Print the string contents
-  let assert Ok(text) = bit_array.from_string(object)
+  let assert Ok(text) = bit_array.to_string(object)
   io.println(text)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import httpc
 ///
 pub fn main() {
   let creds = bucket.credentials(
-    host: "s3-api-host.example.com",
+    base_url: "https://s3-api-host.example.com",
     access_key_id: "YOUR_ACCESS_KEY",
     secret_access_key: "YOUR_SECRET_ACCESS_KEY",
   )

--- a/src/bucket.gleam
+++ b/src/bucket.gleam
@@ -1,6 +1,6 @@
-import gleam/http.{type Scheme}
 import gleam/http/response.{type Response}
 import gleam/option.{type Option}
+import gleam/uri
 
 pub type BucketError {
   InvalidXmlSyntaxError(String)
@@ -22,9 +22,9 @@ pub type ErrorObject {
 /// The creds used to connect to an S3 API.
 pub type Credentials {
   Credentials(
-    scheme: Scheme,
+    scheme: Option(String),
     port: Option(Int),
-    host: String,
+    host: Option(String),
     region: String,
     access_key_id: String,
     secret_access_key: String,
@@ -33,17 +33,19 @@ pub type Credentials {
 }
 
 pub fn credentials(
-  host: String,
+  base_url: String,
   access_key_id: String,
   secret_access_key: String,
 ) -> Credentials {
+  let assert Ok(parsed_url) = uri.parse(base_url)
+
   Credentials(
-    host:,
+    host: parsed_url.host,
+    port: parsed_url.port,
+    scheme: parsed_url.scheme,
+    region: "eu-west-1",
     access_key_id:,
     secret_access_key:,
-    region: "eu-west-1",
-    port: option.None,
-    scheme: http.Https,
     session_token: option.None,
   )
 }
@@ -51,16 +53,6 @@ pub fn credentials(
 /// Set the region for the credentials.
 pub fn with_region(creds: Credentials, region: String) -> Credentials {
   Credentials(..creds, region:)
-}
-
-/// Set the port for the credentials.
-pub fn with_port(creds: Credentials, port: Int) -> Credentials {
-  Credentials(..creds, port: option.Some(port))
-}
-
-/// Set the scheme for the credentials. You should use HTTPS unless not possible.
-pub fn with_scheme(creds: Credentials, scheme: http.Scheme) -> Credentials {
-  Credentials(..creds, scheme:)
 }
 
 /// Set the optional session token, which could have given via a task or

--- a/src/bucket/internal.gleam
+++ b/src/bucket/internal.gleam
@@ -9,6 +9,7 @@ import gleam/http/request.{type Request, Request}
 import gleam/http/response.{type Response}
 import gleam/list
 import gleam/option.{type Option}
+import gleam/result
 import gleam/uri
 import xmlm
 
@@ -43,14 +44,17 @@ pub fn request(
   }
   let request =
     Request(
-      method,
-      headers,
-      body,
-      creds.scheme,
-      creds.host,
-      creds.port,
-      path,
-      query,
+      method:,
+      headers:,
+      body:,
+      scheme: result.unwrap(
+        http.scheme_from_string(option.unwrap(creds.scheme, "https")),
+        http.Https,
+      ),
+      host: option.unwrap(creds.host, ""),
+      port: creds.port,
+      path:,
+      query:,
     )
   aws4_request.signer(
     creds.access_key_id,

--- a/test/helpers.gleam
+++ b/test/helpers.gleam
@@ -7,15 +7,14 @@ import bucket/head_object
 import bucket/list_buckets
 import bucket/list_objects
 import bucket/put_object
-import gleam/http
 import gleam/httpc
 import gleam/list
 import gleam/option
 
 pub const creds = bucket.Credentials(
-  scheme: http.Http,
+  scheme: option.Some("http"),
   port: option.Some(9000),
-  host: "localhost",
+  host: option.Some("localhost"),
   region: "us-east-1",
   access_key_id: "minioadmin",
   secret_access_key: "miniopass",
@@ -23,9 +22,9 @@ pub const creds = bucket.Credentials(
 )
 
 pub const bad_creds = bucket.Credentials(
-  scheme: http.Http,
+  scheme: option.Some("http"),
   port: option.Some(9000),
-  host: "localhost",
+  host: option.Some("localhost"),
   region: "us-east-1",
   access_key_id: "unknown",
   secret_access_key: "nope",


### PR DESCRIPTION
Simplify `credential` configuration by accepting a single `base_url` parameter instead of setting up `host`, `port`, and `scheme` manually by the constructor functions `with_port` and `with_scheme`.

Parsing `base_url` by `gleam/uri` to get `host`, `port`, and `scheme`:

```rust
pub fn credentials(
  base_url: String,
  access_key_id: String,
  secret_access_key: String,
) -> Credentials {
  let assert Ok(parsed_url) = uri.parse(base_url)

  Credentials(
    host: parsed_url.host,
    port: parsed_url.port,
    scheme: parsed_url.scheme,
    region: "eu-west-1",
    access_key_id:,
    secret_access_key:,
    session_token: option.None,
  )
}
```

User can now specify a `base_url` in `bucket.credentials`, and `gleam/uri` would automatically parse the URI in the background.

```rust
let creds = bucket.credentials(
  base_url: "https://s3-api-host.example.com:port",
  access_key_id: "YOUR_ACCESS_KEY",
  secret_access_key: "YOUR_SECRET_ACCESS_KEY",
)
```