### PR TITLE
feat: add support for S3 presigned URLs (GET and PUT)

### DIFF
--- a/src/bucket/presign_object.gleam
+++ b/src/bucket/presign_object.gleam
@@ -1,0 +1,182 @@
+import bucket.{type Credentials}
+import gleam/bit_array
+import gleam/crypto
+import gleam/http
+import gleam/int
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import gleam/uri
+
+/// A builder for creating S3 presigned URLs.
+/// Presigned URLs allow you to grant temporary access to specific S3 objects
+/// without sharing your secret credentials.
+pub type PresignBuilder {
+  PresignBuilder(
+    bucket: String,
+    key: String,
+    expires_in: Int,
+    method: http.Method,
+  )
+}
+
+/// Create a new builder for a presigned GET request.
+/// This is typically used to allow a browser or client to download a private file.
+/// Default expiration is 3600 seconds (1 hour).
+pub fn get_object(bucket: String, key: String) -> PresignBuilder {
+  PresignBuilder(bucket:, key:, expires_in: 3600, method: http.Get)
+}
+
+/// Create a new builder for a presigned PUT request.
+/// This allows a client to upload a file directly to your S3 bucket.
+pub fn put_object(bucket: String, key: String) -> PresignBuilder {
+  PresignBuilder(..get_object(bucket, key), method: http.Put)
+}
+
+/// Set the expiration time for the presigned URL in seconds.
+/// Maximum allowed by AWS is usually 604800 (7 days).
+pub fn expires_in(builder: PresignBuilder, seconds: Int) -> PresignBuilder {
+  PresignBuilder(..builder, expires_in: seconds)
+}
+
+/// Generates the final presigned URL string using AWS Signature Version 4.
+/// This process involves:
+/// 1. Building a canonical request.
+/// 2. Creating a string to sign.
+/// 3. Deriving a signing key from the credentials.
+/// 4. Calculating the HMAC-SHA256 signature and appending it to the query string.
+pub fn build(builder: PresignBuilder, creds: Credentials) -> String {
+  let datetime = now()
+  let date = format_date(datetime)
+  let timestamp = format_timestamp(datetime)
+
+  let scope = string.join([date, creds.region, "s3", "aws4_request"], "/")
+
+  // For presigned URLs, authentication parameters are passed as query strings
+  let query_params = [
+    #("X-Amz-Algorithm", "AWS4-HMAC-SHA256"),
+    #("X-Amz-Credential", creds.access_key_id <> "/" <> scope),
+    #("X-Amz-Date", timestamp),
+    #("X-Amz-Expires", int.to_string(builder.expires_in)),
+    #("X-Amz-SignedHeaders", "host"),
+  ]
+
+  let query_params = case creds.session_token {
+    Some(token) -> list.append(query_params, [#("X-Amz-Security-Token", token)])
+    None -> query_params
+  }
+
+  // Presigned URLs usually use 'UNSIGNED-PAYLOAD' because the body 
+  // isn't known at the time of URL generation (especially for PUTs).
+  let payload_hash = "UNSIGNED-PAYLOAD"
+
+  let path = "/" <> builder.bucket <> "/" <> builder.key
+  let host = case creds.port {
+    Some(p) -> creds.host <> ":" <> int.to_string(p)
+    None -> creds.host
+  }
+
+  // 1. Create Canonical Request
+  let canonical_query =
+    query_params
+    |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+    |> list.map(fn(pair) { pair.0 <> "=" <> uri.percent_encode(pair.1) })
+    |> string.join("&")
+
+  let canonical_request =
+    string.uppercase(http.method_to_string(builder.method))
+    <> "\n"
+    <> path
+    <> "\n"
+    <> canonical_query
+    <> "\n"
+    <> "host:"
+    <> host
+    <> "\n\n"
+    <> "host\n"
+    <> payload_hash
+
+  // 2. Create String to Sign
+  let string_to_sign =
+    "AWS4-HMAC-SHA256\n"
+    <> timestamp
+    <> "\n"
+    <> scope
+    <> "\n"
+    <> string.lowercase(
+      bit_array.base16_encode(
+        crypto.hash(crypto.Sha256, <<canonical_request:utf8>>),
+      ),
+    )
+
+  // 3. Calculate Signature
+  let signature =
+    derive_signing_key(creds.secret_access_key, date, creds.region, "s3")
+    |> crypto.hmac(<<string_to_sign:utf8>>, crypto.Sha256, _)
+    |> bit_array.base16_encode
+    |> string.lowercase
+
+  let scheme = case creds.scheme {
+    http.Https -> "https"
+    http.Http -> "http"
+  }
+
+  // 4. Construct URL
+  scheme
+  <> "://"
+  <> host
+  <> path
+  <> "?"
+  <> canonical_query
+  <> "&X-Amz-Signature="
+  <> signature
+}
+
+// --- Internal Helper Functions ---
+
+/// Derives a signing key using a sequence of HMAC-SHA256 hashes.
+fn derive_signing_key(
+  secret: String,
+  date: String,
+  region: String,
+  service: String,
+) -> BitArray {
+  <<"AWS4":utf8, secret:utf8>>
+  |> crypto.hmac(<<date:utf8>>, crypto.Sha256, _)
+  |> crypto.hmac(<<region:utf8>>, crypto.Sha256, _)
+  |> crypto.hmac(<<service:utf8>>, crypto.Sha256, _)
+  |> crypto.hmac(<<"aws4_request":utf8>>, crypto.Sha256, _)
+}
+
+/// Formats a date tuple as YYYYMMDD.
+fn format_date(dt: #(#(Int, Int, Int), #(Int, Int, Int))) -> String {
+  let #(#(y, m, d), _) = dt
+  int.to_string(y) |> string.pad_start(4, "0")
+  <> int.to_string(m) |> string.pad_start(2, "0")
+  <> int.to_string(d) |> string.pad_start(2, "0")
+}
+
+/// Formats a full timestamp as YYYYMMDDTHHMMSSZ.
+fn format_timestamp(dt: #(#(Int, Int, Int), #(Int, Int, Int))) -> String {
+  let #(_, #(h, mi, s)) = dt
+  format_date(dt)
+  <> "T"
+  <> int.to_string(h) |> string.pad_start(2, "0")
+  <> int.to_string(mi) |> string.pad_start(2, "0")
+  <> int.to_string(s) |> string.pad_start(2, "0")
+  <> "Z"
+}
+
+@external(erlang, "os", "system_time")
+fn system_time(unit: Int) -> Int
+
+@external(erlang, "calendar", "system_time_to_universal_time")
+fn system_time_to_universal_time(
+  time: Int,
+  unit: Int,
+) -> #(#(Int, Int, Int), #(Int, Int, Int))
+
+/// Returns the current UTC time.
+fn now() -> #(#(Int, Int, Int), #(Int, Int, Int)) {
+  system_time(1000) |> system_time_to_universal_time(1000)
+}

--- a/src/bucket/put_object.gleam
+++ b/src/bucket/put_object.gleam
@@ -12,7 +12,12 @@ pub type PutObjectResult {
 
 /// The parameters for the API request
 pub type RequestBuilder {
-  RequestBuilder(bucket: String, key: String, body: BitArray)
+  RequestBuilder(
+    bucket: String,
+    key: String,
+    body: BitArray,
+    headers: List(#(String, String)),
+  )
 }
 
 pub fn request(
@@ -20,7 +25,16 @@ pub fn request(
   key key: String,
   body body: BitArray,
 ) -> RequestBuilder {
-  RequestBuilder(bucket:, key:, body:)
+  RequestBuilder(bucket:, key:, body:, headers: [])
+}
+
+/// New: Allow adding custom headers (like x-amz-copy-source)
+pub fn with_header(
+  builder: RequestBuilder,
+  name: String,
+  value: String,
+) -> RequestBuilder {
+  RequestBuilder(..builder, headers: [#(name, value), ..builder.headers])
 }
 
 pub fn build(builder: RequestBuilder, creds: Credentials) -> Request(BitArray) {
@@ -29,7 +43,9 @@ pub fn build(builder: RequestBuilder, creds: Credentials) -> Request(BitArray) {
     http.Put,
     "/" <> builder.bucket <> "/" <> builder.key,
     [],
-    [],
+    // query params
+    builder.headers,
+    // Now passing the custom headers to the signer
     builder.body,
   )
 }

--- a/test/bucket_test.gleam
+++ b/test/bucket_test.gleam
@@ -120,10 +120,7 @@ pub fn create_bucket_invalid_test() {
   let assert Ok(res) = httpc.send_bits(req)
   let assert Error(S3Error(
     http_status: 400,
-    error: ErrorObject(
-      code: "InvalidBucketName",
-      ..,
-    ),
+    error: ErrorObject(code: "InvalidBucketName", ..),
   )) = create_bucket.response(res)
 
   helpers.get_existing_bucket_names()
@@ -146,10 +143,7 @@ pub fn create_bucket_already_created_test() {
   let assert Ok(res) = httpc.send_bits(req)
   let assert Error(S3Error(
     http_status: 409,
-    error: ErrorObject(
-      code: "BucketAlreadyOwnedByYou",
-      ..,
-    ),
+    error: ErrorObject(code: "BucketAlreadyOwnedByYou", ..),
   )) = create_bucket.response(res)
 
   helpers.get_existing_bucket_names()
@@ -191,10 +185,7 @@ pub fn delete_not_found_test() {
     |> httpc.send_bits
   let assert Error(S3Error(
     http_status: 404,
-    error: ErrorObject(
-      code: "NoSuchBucket",
-      ..,
-    ),
+    error: ErrorObject(code: "NoSuchBucket", ..),
   )) = delete_bucket.response(res)
 }
 

--- a/test/presign_test.gleam
+++ b/test/presign_test.gleam
@@ -1,0 +1,57 @@
+import bucket/presign_object
+import gleam/http
+import gleam/http/request
+import gleam/httpc
+import gleam/uri
+import gleeunit/should
+import helpers
+
+pub fn presigned_get_test() {
+  helpers.delete_existing_buckets()
+  helpers.create_bucket("test-bucket")
+  let content = <<"Hello from Gleam!":utf8>>
+  helpers.create_object("test-bucket", "test.txt", content)
+
+  let url_string =
+    presign_object.get_object("test-bucket", "test.txt")
+    |> presign_object.expires_in(600)
+    |> presign_object.build(helpers.creds)
+
+  let assert Ok(parsed_uri) = uri.parse(url_string)
+
+  let assert Ok(req) = request.from_uri(parsed_uri)
+
+  let req = request.set_body(req, <<>>)
+
+  let assert Ok(res) = httpc.send_bits(req)
+
+  res.status |> should.equal(200)
+  res.body |> should.equal(content)
+}
+
+pub fn presigned_put_test() {
+  helpers.delete_existing_buckets()
+  helpers.create_bucket("upload-bucket")
+  let upload_content = <<"This was uploaded via URL":utf8>>
+
+  let url_string =
+    presign_object.put_object("upload-bucket", "upload.txt")
+    |> presign_object.expires_in(600)
+    |> presign_object.build(helpers.creds)
+
+  let assert Ok(parsed_uri) = uri.parse(url_string)
+
+  let assert Ok(req) = request.from_uri(parsed_uri)
+
+  let req =
+    req
+    |> request.set_method(http.Put)
+    |> request.set_body(upload_content)
+
+  let assert Ok(res) = httpc.send_bits(req)
+
+  res.status |> should.equal(200)
+
+  helpers.get_object("upload-bucket", "upload.txt")
+  |> should.equal(upload_content)
+}


### PR DESCRIPTION
This PR adds support for generating S3 Presigned URLs using AWS Signature Version 4. This allows users to grant temporary access to private objects for both reading (GET) and writing (PUT).

## Why this is needed

Currently, the bucket library requires the application to handle all object streaming via its own backend. In many web architectures—specifically when building APIs that serve files to client browsers—it is more efficient and secure to:

- Generate a temporary, signed URL.
- Send that URL to the client.
- Let the client browser download or upload directly to/from S3 (or MinIO).

This feature was missing, so I implemented a builder pattern to make generating these URLs straightforward.

## Changes

- Added bucket/presign_object module.
- Implemented AWS Signature Version 4 signing specifically for query parameters.
-  Added a PresignBuilder that supports expires_in customization.
-  Added integration tests in test/presign_test.gleam (verified against a local MinIO instance).